### PR TITLE
Install `bc` in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -24,6 +24,10 @@ sep "Installing z3 and python3"
 
 sudo apt install z3 python3
 
+# Install bc
+
+sudo apt-get install -y bc
+
 # Check for Racket installation
 
 sep "Checking Racket installation ..."


### PR DESCRIPTION
I was getting this error while running the setup:

```bash
Checking Racket installation ... 
./setup.sh: line 45: bc: command not found
FAILED : Racket 8.1 is installed, but we need at least 6.9.
```

(because bc was not installed, we get a wrong failure reason at the end)